### PR TITLE
updating olm config to have proper information

### DIFF
--- a/olm/olmconfig.yaml
+++ b/olm/olmconfig.yaml
@@ -13,7 +13,7 @@ description: |-
   **About Amazon CloudWatch Logs**
 
 
-  {ADD YOUR DESCRIPTION HERE}
+  You can use Amazon CloudWatch Logs to monitor, store, and access your log files from Amazon Elastic Compute Cloud (Amazon EC2) instances, AWS CloudTrail, Route 53, and other sources.
 
 
   **About the AWS Controllers for Kubernetes**
@@ -28,13 +28,11 @@ description: |-
 
   Please follow the following link: [Red Hat OpenShift](https://aws-controllers-k8s.github.io/community/docs/user-docs/openshift/)
 samples:
-- kind: ExampleCustomKind
-  spec: '{}'
-- kind: SecondExampleCustomKind
+- kind: LogGroup
   spec: '{}'
 maintainers:
 - name: "cloudwatch maintainer team"
   email: "ack-maintainers@amazon.com"
 links:
 - name: Amazon CloudWatch Logs Developer Resources
-  url: https://aws.amazon.com/CloudWatch Logs/developer-resources/
+  url: https://aws.amazon.com/cloudwatch/developer-resources/


### PR DESCRIPTION


Issue #, if available:

 - Relates: aws-controllers-k8s/community#1923

Description of changes:
Updating the olm config to have proper product information/links, as well as adding `LogGroup` CR to the samples

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
